### PR TITLE
Markush/connection error handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ ignore = [
   "ANN101",
   # Missing docstring in `__init__`
   "D107",
+  # Missing type annotation for `*args`
+  "ANN002",
+  # Missing type annotation for `**kwargs`
+  "ANN003",
 ]
 
 [tool.ruff.pydocstyle]

--- a/src/labone/core/_exception_handler.py
+++ b/src/labone/core/_exception_handler.py
@@ -1,0 +1,76 @@
+"""Exception handler module for connection errors.
+
+This module provides a helper functionality to wrap asyncronous callables
+and catch errors happening within them.
+"""
+from functools import wraps
+from typing import Callable, TypeVar
+
+import capnp
+
+from labone.core import errors
+
+T = TypeVar("T")
+
+
+def _capnp_dynamic_schema_error_handler(  # noqa: D417
+    callable_: Callable[..., T],
+    *args,
+    **kwargs,
+) -> T:
+    """Handler for dynamic `capnp` schema errors.
+
+    Translates `capnp.lib.capnp.KjException` exceptions into library errors.
+
+    Args:
+        callable_: A callable.
+
+    Raises:
+        LabOneCoreError: Input values do not match the schema.
+    """
+    try:
+        return callable_(*args, **kwargs)
+    except capnp.lib.capnp.KjException as error:
+        raise errors.LabOneCoreError(str(error)) from error
+
+
+def wrap_dynamic_capnp(
+    callable_: Callable[..., capnp.lib.capnp._RemotePromise],  # noqa: SLF001
+) -> Callable[..., capnp.lib.capnp._RemotePromise]:  # noqa: SLF001
+    """Wraps a dynamic `capnp` callable.
+
+    Translates `capnp` exceptions into library errors.
+    Calls the returned promise's `a_wait()` function, therefore
+    the wrapped functions only need to be awaited.
+
+    The decorator does two things:
+
+        - Catches schema errors, for example, invalid input types
+
+        - Catches connection errors
+
+    Example usage::
+
+        from labone.core._exception_handler import wrap_dynamic_capnp
+
+        coro = wrap_dynamic_capnp(dynamic_capnp_callable)
+        await coro(1, 2)
+
+    Args:
+        callable_: A callable that returns `capnp.lib.capnp._RemotePromise`.
+
+    Raises:
+        LabOneCoreError: Schema error.
+        LabOneConnectionError: Connection error.
+    """
+
+    @wraps(callable_)
+    async def wrapper(*args, **kwargs) -> capnp.lib.capnp._Response:  # noqa: SLF001
+        try:
+            coro = _capnp_dynamic_schema_error_handler(callable_, *args, **kwargs)
+            return await coro.a_wait()
+        # Handle connection errors
+        except capnp.lib.capnp.KjException as error:
+            raise errors.LabOneConnectionError(str(error)) from error
+
+    return wrapper

--- a/tests/core/resources/testfile.capnp
+++ b/tests/core/resources/testfile.capnp
@@ -1,0 +1,5 @@
+@0xb6c21289d5437345;
+
+struct TestObject {
+  name @0 :Text;
+}

--- a/tests/core/test_create_session.py
+++ b/tests/core/test_create_session.py
@@ -4,9 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from labone.core import connection_layer, session
-from labone.core.resources import (  # type: ignore[attr-defined]
-    session_protocol_capnp,
-)
+from labone.core.resources import session_protocol_capnp  # type: ignore[attr-defined]
 
 
 @patch("labone.core.session.create_session_client_stream", autospec=True)

--- a/tests/core/test_exception_handler.py
+++ b/tests/core/test_exception_handler.py
@@ -1,0 +1,77 @@
+from functools import partial
+from pathlib import Path
+
+import capnp
+import pytest
+from labone.core import _exception_handler, errors
+
+capnp.remove_import_hook()
+_testfile = Path(__file__).parent / "resources/testfile.capnp"
+testfile = capnp.load(str(_testfile.resolve()))
+
+
+class TestDynamicSchemaErrorHandler:
+    def test_success(self):
+        testfile.TestObject(name="text")
+        _exception_handler._capnp_dynamic_schema_error_handler(
+            testfile.TestObject,
+            name="text",
+        )
+
+    def test_error_cases(self):
+        with pytest.raises(capnp.KjException):
+            testfile.TestObject(foo=3)
+        with pytest.raises(errors.LabOneCoreError):
+            _exception_handler._capnp_dynamic_schema_error_handler(
+                testfile.TestObject,
+                foo=3,
+            )
+
+
+class TestWrapDynamicCapnp:
+    @staticmethod
+    def dynamic_test_function(err, raise_=True, rval=None):  # noqa: FBT002
+        """A mock of `capnp.lib.capnp._DynamicCapabilityClient`"""
+
+        class RemoteTestPromise:
+            """A mock of `capnp.lib.capnp._RemotePromise`."""
+
+            def __init__(self, err, raise_, rval) -> None:
+                self._err = err
+                self._raise = raise_
+                self._rval = rval
+
+            async def a_wait(self):
+                if self._raise:
+                    raise self._err
+                return self._rval
+
+        return RemoteTestPromise(err, raise_, rval)
+
+    @pytest.mark.parametrize(
+        ("awaitable_error", "expected"),
+        [
+            (capnp.KjException("text"), errors.LabOneConnectionError("text")),
+            (RuntimeError("text"), RuntimeError("text")),
+            (ValueError("text"), ValueError("text")),
+        ],
+    )
+    @pytest.mark.asyncio()
+    async def test_error_cases(self, awaitable_error, expected):
+        f = partial(TestWrapDynamicCapnp.dynamic_test_function, awaitable_error)
+        with pytest.raises(type(awaitable_error)):
+            await f().a_wait()
+        with pytest.raises(type(expected)):  # noqa: PT012
+            func = _exception_handler.wrap_dynamic_capnp(f)
+            await func()
+
+    @pytest.mark.asyncio()
+    async def test_success(self):
+        rval = 123
+        f = partial(
+            TestWrapDynamicCapnp.dynamic_test_function,
+            None,
+            raise_=False,
+            rval=rval,
+        )
+        assert await f().a_wait() == rval


### PR DESCRIPTION
This PR add a dynamic `pycapnp` error handler.

It catches `capnp.lib.capnp.KjException` error and translates them to the `labone` library errors.