### PR TITLE
Suppress KjExceptions from traceback

### DIFF
--- a/src/labone/core/session.py
+++ b/src/labone/core/session.py
@@ -158,10 +158,10 @@ async def _send_and_wait_request(
     # TODO(markush): Raise more specific error types.  # noqa: TD003, FIX002
     except capnp.lib.capnp.KjException as error:
         msg = error.description
-        raise errors.LabOneConnectionError(msg) from error
+        raise errors.LabOneConnectionError(msg) from None
     except Exception as error:  # noqa: BLE001
         msg = str(error)
-        raise errors.LabOneConnectionError(msg) from error
+        raise errors.LabOneConnectionError(msg) from None
 
 
 class KernelSession:
@@ -303,15 +303,15 @@ class KernelSession:
             raise TypeError(msg)  # noqa: TRY200, B904
         try:
             request.flags = int(flags)
-        except capnp.KjException as error:
+        except capnp.KjException:
             field_type = request_field_type_description(request, "flags")
             msg = f"`flags` value is out-of-bounds, it must be of type {field_type}."
             raise ValueError(
                 msg,
-            ) from error
-        except (TypeError, ValueError) as error:
+            ) from None
+        except (TypeError, ValueError):
             msg = "`flags` must be an integer."
-            raise TypeError(msg) from error
+            raise TypeError(msg) from None
         response = await _send_and_wait_request(request)
         return list(response.paths)
 
@@ -392,18 +392,18 @@ class KernelSession:
             request.pathExpression = path
         except Exception:  # noqa: BLE001
             msg = "`path` must be a string."
-            raise TypeError(msg)  # noqa: TRY200, B904
+            raise TypeError(msg) from None
         try:
             request.flags = int(flags)
-        except capnp.KjException as error:
+        except capnp.KjException:
             field_type = request_field_type_description(request, "flags")
             msg = f"`flags` value is out-of-bounds, it must be of type {field_type}."
             raise ValueError(
                 msg,
-            ) from error
-        except (TypeError, ValueError) as error:
+            ) from None
+        except (TypeError, ValueError):
             msg = "`flags` must be an integer."
-            raise TypeError(msg) from error
+            raise TypeError(msg) from None
         response = await _send_and_wait_request(request)
         return json.loads(response.nodeProps)
 
@@ -512,10 +512,10 @@ class KernelSession:
         )
         try:
             subscription.path = path
-        except (AttributeError, TypeError, capnp.KjException) as error:
+        except (AttributeError, TypeError, capnp.KjException):
             field_type = request_field_type_description(subscription, "path")
             msg = f"`path` attribute must be of type {field_type}."
-            raise TypeError(msg) from error
+            raise TypeError(msg) from None
         request = self._session.subscribe_request()
         request.subscription = subscription
         response = await _send_and_wait_request(request)

--- a/src/labone/core/value.py
+++ b/src/labone/core/value.py
@@ -92,10 +92,10 @@ class AnnotatedValue:
         message = session_protocol_capnp.AnnotatedValue.new_message()
         try:
             message.metadata.path = self.path
-        except (AttributeError, TypeError, capnp.KjException) as error:
+        except (AttributeError, TypeError, capnp.KjException):
             field_type = request_field_type_description(message.metadata, "path")
             msg = f"`path` attribute must be of type {field_type}."
-            raise TypeError(msg) from error
+            raise TypeError(msg) from None
         message.value = _value_from_python_types(self.value)
         return message
 


### PR DESCRIPTION
Suppress unhelpful traceback raised from `_send_and_wait_request()`

## Before

```
KjException                               Traceback (most recent call last)
File ~/Documents/zhinst/zpy/labone/src/labone/core/session.py:155, in _send_and_wait_request(request)
    154 try:
--> 155     return await request.send().a_wait()
    156 # TODO(markush): Raise more specific error types.  # noqa: TD003, FIX002

File ~/.pyenv/versions/3.9.13/envs/pylabone/lib/python3.9/site-packages/capnp/lib/capnp.pyx:1941, in a_wait()

KjException: capnp/rpc.c++:2421: disconnected: Peer disconnected.
stack: 12cd0c044 12cd036a0 12cbe0914 12cbe188c

The above exception was the direct cause of the following exception:

LabOneConnectionError                     Traceback (most recent call last)
Cell In[4], line 1
----> 1 await ses.list_nodes_info("*")

File ~/Documents/zhinst/zpy/labone/src/labone/core/session.py:407, in Session.list_nodes_info(self, path, flags)
    405     msg = "`flags` must be an integer."
    406     raise TypeError(msg) from error
--> 407 response = await _send_and_wait_request(request)
    408 return json.loads(response.nodeProps)

File ~/Documents/zhinst/zpy/labone/src/labone/core/session.py:159, in _send_and_wait_request(request)
    157 except capnp.lib.capnp.KjException as error:
    158     msg = error.description
--> 159     raise errors.LabOneConnectionError(msg) from error
    160 except Exception as error:  # noqa: BLE001
    161     msg = str(error)

LabOneConnectionError: Peer disconnected.
```


## After

```
LabOneConnectionError                     Traceback (most recent call last)
Cell In[19], line 1
----> 1 await ses.list_nodes_info("*")

File ~/Documents/zhinst/zpy/labone/src/labone/core/session.py:414, in list_nodes_info(self, path, flags)
    409 async def set_value(self, value: AnnotatedValue) -> AnnotatedValue:
    410     """Set the value of a node.
    411 
    412     Args:
    413         value: Annotated value of the node.
--> 414 
    415     Returns:
    416         Acknowledged value from the device.
    417 
    418     Raises:
    419         TypeError: If the node path is of wrong type.
    420         LabOneCoreError: If the node value type is not supported.
    421         LabOneConnectionError: If there is a problem in the connection.
    422     """
    423     # T O D O: To accept list of `AnnotatedValue`s
    424     capnp_value = value.to_capnp()

File ~/Documents/zhinst/zpy/labone/src/labone/core/session.py:163, in _send_and_wait_request(request)
    160     msg = str(error)
    161 # We suppress kjExceptions, as their error message is not really useful to
    162 # the users.
--> 163 raise errors.LabOneConnectionError(msg)

LabOneConnectionError: Peer disconnected.
```