### PR TITLE
Add missing dependency on 'packaging' package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Topic :: Scientific/Engineering",
 ]
-dependencies = ["numpy>=1.20", "pycapnp", "typing_extensions"]
+dependencies = ["numpy>=1.20", "packaging", "pycapnp", "typing_extensions"]
 
 [project.urls]
 Issues = "https://github.com/zhinst/labone-python/issues"


### PR DESCRIPTION
Fixes the following problem in a fresh Python 3.10 venv:

```
❯ python test.py
Traceback (most recent call last):
  File "/tmp/async/test.py", line 2, in <module>
    from labone.core import KernelSession, ServerInfo, DeviceKernelInfo, ZIKernelInfo
  File "/tmp/async/venv/lib/python3.10/site-packages/labone/core/__init__.py", line 7, in <module>
    from labone.core.connection_layer import DeviceKernelInfo, ServerInfo, ZIKernelInfo
  File "/tmp/async/venv/lib/python3.10/site-packages/labone/core/connection_layer.py", line 26, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
```