### PR TITLE
Adapt ShfResultLoggerVectorEstraHeader to the latest LabOne changes

### DIFF
--- a/src/labone/core/shf_vector_data.py
+++ b/src/labone/core/shf_vector_data.py
@@ -52,9 +52,18 @@ class ShfResultLoggerVectorExtraHeader:
     """
 
     timestamp: int
-    timestamp_diff: int
+    job_id: int
+    repetition_id: int
+    data_source: int
     scaling: float
     center_freq: float
+    num_samples: int
+    num_spectr_samples: int
+    num_averages: int
+    num_acquired: int
+    holdoff_errors_reslog: int
+    holdoff_errors_readout: int
+    holdoff_errors_spectr: int
 
     @staticmethod
     def from_binary(
@@ -79,9 +88,18 @@ class ShfResultLoggerVectorExtraHeader:
         if version.minor >= 1:
             return ShfResultLoggerVectorExtraHeader(
                 timestamp=struct.unpack("q", binary[0:8])[0],
-                timestamp_diff=struct.unpack("I", binary[8:12])[0],
+                job_id=struct.unpack("H", binary[8:10])[0],
+                repetition_id=struct.unpack("H", binary[10:12])[0],
+                data_source=struct.unpack("I", binary[12:16])[0],
                 scaling=struct.unpack("d", binary[16:24])[0],
                 center_freq=struct.unpack("d", binary[24:32])[0],
+                num_samples=struct.unpack("I", binary[32:36])[0],
+                num_spectr_samples=struct.unpack("I", binary[36:40])[0],
+                num_averages=struct.unpack("I", binary[40:44])[0],
+                num_acquired=struct.unpack("I", binary[44:48])[0],
+                holdoff_errors_reslog=struct.unpack("H", binary[48:50])[0],
+                holdoff_errors_readout=struct.unpack("H", binary[50:52])[0],
+                holdoff_errors_spectr=struct.unpack("H", binary[52:54])[0],
             )
         msg = str(
             f"Unsupported extra header version: {version} for "

--- a/tests/core/test_shf_vector_data.py
+++ b/tests/core/test_shf_vector_data.py
@@ -212,7 +212,7 @@ def test_shf_result_logger_vector(vector_length, header_version, x, reflection_s
     input_vector = reflection_server.VectorData.new_message()
     input_vector.valueType = VectorValueType.SHF_RESULT_LOGGER_VECTOR_DATA.value
     input_vector.vectorElementType = 2  # uint32
-    header_length = 32
+    header_length = 56
     input_vector.extraHeaderInfo = _construct_extra_header_value(
         header_length=header_length,
         major_version=0,
@@ -228,9 +228,19 @@ def test_shf_result_logger_vector(vector_length, header_version, x, reflection_s
     )
 
     assert extra_header.timestamp == 0
-    assert extra_header.timestamp_diff == 0
+    assert extra_header.timestamp == 0
+    assert extra_header.job_id == 0
+    assert extra_header.repetition_id == 0
+    assert extra_header.data_source == 0
     assert extra_header.scaling == 0.0
     assert extra_header.center_freq == 0.0
+    assert extra_header.num_samples == 0
+    assert extra_header.num_spectr_samples == 0
+    assert extra_header.num_averages == 0
+    assert extra_header.num_acquired == 0
+    assert extra_header.holdoff_errors_reslog == 0
+    assert extra_header.holdoff_errors_readout == 0
+    assert extra_header.holdoff_errors_spectr == 0
 
 
 @pytest.mark.parametrize("vector_length", range(0, 200, 32))


### PR DESCRIPTION
The field in the ShfResultLoggerVectorExtraHeader have changed and new fields have been added. This commit adapt the data class to contain all values.