### PR TITLE
Adding a root property.

### DIFF
--- a/src/labone/nodetree/node.py
+++ b/src/labone/nodetree/node.py
@@ -1142,6 +1142,15 @@ class Node(MetaNode, ABC):
             flexible manner.
         """
 
+    @property
+    def root(self) -> Node:
+        """Providing root node.
+
+        Returns:
+            Root of the tree structure, this node is part of.
+        """
+        return self.tree_manager.path_segments_to_node(())
+
 
 class LeafNode(Node):
     """Node corresponding to a leaf in the path-structure."""

--- a/tests/nodetree/test_node.py
+++ b/tests/nodetree/test_node.py
@@ -745,6 +745,23 @@ class TestNode:
         assert node._path_aliases == "path_aliases"
         assert node.subtree_paths == subtree_paths
 
+    @pytest.mark.parametrize(
+        "path_segments",
+        [
+            (),
+            ("a"),
+            ("a", "b"),
+            ("c", "v", "r"),
+        ],
+    )
+    def test_root(self, path_segments):
+        node = MockNode(path_segments=path_segments)
+        node._tree_manager = create_autospec(NodeTreeManager)
+
+        node.root  # noqa: B018
+
+        node.tree_manager.path_segments_to_node.assert_called_once_with(())
+
 
 class TestLeafNode:
     @pytest.mark.asyncio()


### PR DESCRIPTION
Nodes can retrieve their root directly via a property.