### PR TITLE
Rayk/root property

### DIFF
--- a/src/labone/nodetree/entry_point.py
+++ b/src/labone/nodetree/entry_point.py
@@ -56,8 +56,7 @@ async def construct_nodetree(
         session=session,
         parser=parser,
         path_to_info=path_to_info,
-    )
-
-    return nodetree_manager.construct_nodetree(
         hide_kernel_prefix=hide_kernel_prefix,
     )
+
+    return nodetree_manager.root

--- a/tests/nodetree/conftest.py
+++ b/tests/nodetree/conftest.py
@@ -147,7 +147,7 @@ async def session_zi(session_mock, zi_structure) -> Node:
             path_to_info=zi_structure.nodes_to_info,
             parser=lambda x: x,
         )
-    ).construct_nodetree(
+    ).root(
         hide_kernel_prefix=True,
     )
 
@@ -191,7 +191,8 @@ def zi(request, zi_structure) -> Node:
         session=None,
         path_to_info=nodes_to_info,
         parser=parser,
-    ).construct_nodetree(hide_kernel_prefix=True)
+        hide_kernel_prefix=True,
+    ).root
 
 
 @pytest.fixture()
@@ -341,6 +342,7 @@ class MockNodeTreeManager(NodeTreeManager):
             session=None,
             path_to_info=path_to_info,
             parser=None,
+            hide_kernel_prefix=True,
         )
 
 

--- a/tests/nodetree/test_entry_point.py
+++ b/tests/nodetree/test_entry_point.py
@@ -33,7 +33,8 @@ async def test_construct_nodetree_custom_parser(
     session_mock.list_nodes_info = Mock(return_value=_get_future(list_node_info))
 
     nodetree_mock = Mock()
-    nodetree_mock.construct_nodetree = Mock(return_value="result")
+    nodetree_mock._root_prefix = ()
+    nodetree_mock.root = "result"
 
     with patch(
         "labone.nodetree.entry_point.NodeTreeManager",
@@ -59,8 +60,6 @@ async def test_construct_nodetree_custom_parser(
         session=session_mock,
         path_to_info=list_node_info,
         parser=ANY,
-    )
-    nodetree_mock.construct_nodetree.assert_called_once_with(
         hide_kernel_prefix="hide_kernel_prefix",
     )
     assert tree == "result"

--- a/tests/nodetree/test_node.py
+++ b/tests/nodetree/test_node.py
@@ -745,22 +745,12 @@ class TestNode:
         assert node._path_aliases == "path_aliases"
         assert node.subtree_paths == subtree_paths
 
-    @pytest.mark.parametrize(
-        "path_segments",
-        [
-            (),
-            ("a"),
-            ("a", "b"),
-            ("c", "v", "r"),
-        ],
-    )
-    def test_root(self, path_segments):
-        node = MockNode(path_segments=path_segments)
+    def test_root(self):
+        node = MockNode(())
         node._tree_manager = create_autospec(NodeTreeManager)
+        node._tree_manager.root = "root"
 
-        node.root  # noqa: B018
-
-        node.tree_manager.path_segments_to_node.assert_called_once_with(())
+        assert node.root == "root"
 
 
 class TestLeafNode:


### PR DESCRIPTION
For the node.root property, hiding the path segments is usually the desired behavior. 