### PR TITLE
Redesign result nodes.

### DIFF
--- a/src/labone/dataserver.py
+++ b/src/labone/dataserver.py
@@ -60,7 +60,6 @@ class DataServer(PartialNode):
         super().__init__(
             tree_manager=model_node.tree_manager,
             path_segments=model_node.path_segments,
-            path_aliases=model_node.path_aliases,
             subtree_paths=model_node.subtree_paths,
         )
 

--- a/src/labone/instrument.py
+++ b/src/labone/instrument.py
@@ -41,7 +41,6 @@ class Instrument(PartialNode):
             tree_manager=model_node.tree_manager,
             path_segments=model_node.path_segments,
             subtree_paths=model_node.subtree_paths,
-            path_aliases=model_node.path_aliases,
         )
 
     @staticmethod

--- a/src/labone/nodetree/helper.py
+++ b/src/labone/nodetree/helper.py
@@ -168,22 +168,6 @@ def split_path(path: LabOneNodePath) -> list[NormalizedPathSegment]:
     return path_segments[first_item_index:]
 
 
-def get_prefix(path: LabOneNodePath, segment_count: int) -> LabOneNodePath:
-    """Get a path consisting only of the first n segments of the original path.
-
-    Args:
-        path: Path, the prefix should be taken from.
-        segment_count: Number of segments, which should be included. If there are
-            not enough segments, all available ones are included.
-
-    Returns:
-        A path, similar to the given one, but bounded in terms of number of segments.
-    """
-    segments = split_path(path)
-    first_segments = segments[:segment_count]
-    return join_path(first_segments)
-
-
 def normalize_path_segment(path_segment: str | int) -> NormalizedPathSegment:
     """Bring segment into a standard form.
 

--- a/tests/nodetree/test_result_node.py
+++ b/tests/nodetree/test_result_node.py
@@ -1,0 +1,183 @@
+import pytest
+from labone.core.value import AnnotatedValue
+from labone.nodetree.errors import LabOneInvalidPathError
+
+from tests.mock_server_for_testing import get_mocked_node
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node():
+    node = await get_mocked_node(
+        {"/a/b/c/d": {}},
+    )
+    response = await node.a.b()
+    assert response.path_segments == ()
+    response.a.b.c.d  # noqa: B018 # path valid
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_multiple_subpaths():
+    node = await get_mocked_node(
+        {
+            "/a/c": {},
+            "/a/d": {},
+        },
+    )
+
+    response = await node.a()
+    assert response.path_segments == ()
+    response.a.c  # noqa: B018 # path valid
+    response.a.d  # noqa: B018 # path valid
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_long_bracket_subpathing():
+    node = await get_mocked_node(
+        {"/a/b/c": {}},
+    )
+    response = await node()
+    response["a/b/c"]  # path valid
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_bracket_subpathing():
+    node = await get_mocked_node(
+        {"/a/b/c": {}},
+    )
+    response = await node()
+    response["a"]["b"]["c"]  # path valid
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_bracket_integer_subpathing():
+    node = await get_mocked_node({"/0": {}})
+    response = await node()
+    response[0]  # path valid
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_wrong_path_raises():
+    node = await get_mocked_node({"/a": {}})
+    response = await node()
+    with pytest.raises(LabOneInvalidPathError):
+        response.b  # noqa: B018
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_too_long_path_raises():
+    node = await get_mocked_node({"/a": {}})
+    response = await node()
+    with pytest.raises(AttributeError):  # will be a AnnotatedValue Attribute error
+        response.a.b  # noqa: B018
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_too_long_bracket_path_raises():
+    node = await get_mocked_node({"/a": {}})
+    response = await node()
+    with pytest.raises(LabOneInvalidPathError):
+        response["a/b"]
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_iterate_through_leaves():
+    paths = {"/a/b/c", "/a/b/d", "/a/b/e"}
+    node = await get_mocked_node(
+        {p: {} for p in paths},
+    )
+    response = await node.a()
+    assert paths == {leaf.path for leaf in response.results()}
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_iterate_through_leaves_partial_scope():
+    paths = {"/a/b/c", "/a/b/d", "/x/y"}
+    node = await get_mocked_node(
+        {p: {} for p in paths},
+    )
+    response = await node()
+
+    # results shall only give results agreing to the current path prefix
+    assert {"/x/y"} == {leaf.path for leaf in response.x.results()}
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_values_as_leafs():
+    node = await get_mocked_node({"/a/b": {}})
+    result = await node()
+    assert isinstance(result.a.b, AnnotatedValue)
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_contains_next_segment():
+    node = await get_mocked_node({"/a/b": {}, "/a/c": {}})
+    result = await node()
+    assert "a" in result
+    assert "b" in result.a
+    assert "c" in result.a
+    assert "d" not in result.a
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_contains_subnode():
+    node = await get_mocked_node({"/a/b": {}})
+    result = await node()
+    assert result.a in result
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_contains_value_at_leaf():
+    node = await get_mocked_node({"/a": {}})
+    result = await node()
+    assert result.a in result
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_only_matches_accessable():
+    node = await get_mocked_node({"/a/b/c": {}, "/a/x/c": {}})
+    response = await node.a.b()  # different pattern
+    with pytest.raises(LabOneInvalidPathError):
+        response.a.x  # noqa: B018
+
+
+@pytest.mark.asyncio()
+async def test_partial_get_result_node_only_access_same_node_repeatedly():
+    node = await get_mocked_node({"/a/b": {}})
+    response = await node()
+    for _ in range(10):
+        response.a.b  # noqa: B018
+
+
+@pytest.mark.asyncio()
+async def test_wildcard_get_result_node_basic_behavior():
+    node = await get_mocked_node({"/a/b/c": {}})
+    response = await node.a["*"].c()
+    assert response.path_segments == ()
+    response.a.b.c  # noqa: B018
+
+
+@pytest.mark.asyncio()
+async def test_wildcard_get_result_node_hide_prefix():
+    node = await get_mocked_node(
+        {"/a/b/c": {}},
+        hide_kernel_prefix=True,
+    )
+    response = await node["*"].c()
+    assert response.path_segments == ("a",)
+    response.b.c  # noqa: B018
+
+
+@pytest.mark.asyncio()
+async def test_wildcard_get_result_node_multiple_matches():
+    node = await get_mocked_node({"/a/b/c": {}, "/a/x/c": {}})
+    response = await node.a["*"].c()
+    response.a.b.c  # noqa: B018
+    response.a.x.c  # noqa: B018
+
+
+@pytest.mark.asyncio()
+async def test_wildcard_get_result_node_only_matches_accessable():
+    node = await get_mocked_node({"/a/b/c": {}})
+    response = await node.a["*"].d()  # different pattern
+    with pytest.raises(LabOneInvalidPathError):
+        response.a.b.c  # noqa: B018

--- a/tests/test_dataserver.py
+++ b/tests/test_dataserver.py
@@ -15,7 +15,6 @@ class MockModelNode:
     def __init__(self):
         self.tree_manager = "tree_manager"
         self.path_segments = "path_segments"
-        self.path_aliases = "path_aliases"
         self.subtree_paths = "subtree_paths"
 
 


### PR DESCRIPTION
The former way of using wildcard get results prooved to be not very intuitive. Also result nodes should work consistently through wildcards and and partial nodes. This is now ensured.

Through these refactorings, some logic became obsolete, including the path aliasing and redirecting. This was therefore removed.