### PR TITLE
Introducing add_nodes

### DIFF
--- a/src/labone/mock/automatic_session_functionality.py
+++ b/src/labone/mock/automatic_session_functionality.py
@@ -74,19 +74,12 @@ class AutomaticSessionFunctionality(SessionMockFunctionality):
     ) -> None:
         # storing state and tree structure, info and subscriptions
         # set all existing paths to 0.
-        default_info: NodeInfoType = {
-            "Description": "",
-            "Properties": "Read, Write, Setting",
-            "Type": "Integer (64 bit)",
-            "Unit": "None",
-            "Node": "",
-        }
 
         self.memory: dict[LabOneNodePath, PathData] = {}
         for path, given_info in paths_to_info.items():
-            info = default_info.copy()
+            info = NodeInfo.plain_default_info(path=path)
+            info.update({"Type": "Integer (64 bit)"})  # for mock, int nodes are default
             info.update(given_info)
-            info["Node"] = path
             self.memory[path] = PathData(
                 value=0,
                 info=NodeInfo(info),

--- a/tests/mock_server_for_testing.py
+++ b/tests/mock_server_for_testing.py
@@ -44,7 +44,8 @@ async def get_unittest_mocked_node(
     """Minimal unittest mock.
 
     Use when no calls to the server are tested.
-    This way, the tests do not depend on the mock server.
+    This way, the tests do not depend on the labone-python
+    mock server.
     """
     session_mock = Mock(spec=Session)
     session_mock.list_nodes_info.return_value = (


### PR DESCRIPTION
Introduce functions to add nodes to an existing node tree. This is a fallback when the `list_nodes_info` call is not working as expected, or one wants to test the specific behavior of the data server.