### PR TITLE
Making sure to always use lower paths.

### DIFF
--- a/src/labone/core/session.py
+++ b/src/labone/core/session.py
@@ -591,7 +591,8 @@ class Session:
     async def get_with_expression(
         self,
         path_expression: LabOneNodePath,
-        flags: ListNodesFlags | int = ListNodesFlags.ABSOLUTE
+        flags: ListNodesFlags
+        | int = ListNodesFlags.ABSOLUTE
         | ListNodesFlags.RECURSIVE
         | ListNodesFlags.LEAVES_ONLY
         | ListNodesFlags.EXCLUDE_STREAMING
@@ -654,7 +655,8 @@ class Session:
         queue_type: None = None,
         parser_callback: t.Callable[[AnnotatedValue], AnnotatedValue] | None = None,
         get_initial_value: bool = False,
-    ) -> DataQueue: ...
+    ) -> DataQueue:
+        ...
 
     @t.overload
     async def subscribe(
@@ -664,7 +666,8 @@ class Session:
         queue_type: type[QueueProtocol],
         parser_callback: t.Callable[[AnnotatedValue], AnnotatedValue] | None = None,
         get_initial_value: bool = False,
-    ) -> QueueProtocol: ...
+    ) -> QueueProtocol:
+        ...
 
     async def subscribe(
         self,

--- a/src/labone/core/subscription.py
+++ b/src/labone/core/subscription.py
@@ -105,13 +105,15 @@ class DataQueue(asyncio.Queue):
         )
 
     @t.overload
-    def fork(self, queue_type: None) -> DataQueue: ...
+    def fork(self, queue_type: None) -> DataQueue:
+        ...
 
     @t.overload
     def fork(
         self,
         queue_type: type[QueueProtocol],
-    ) -> QueueProtocol: ...
+    ) -> QueueProtocol:
+        ...
 
     def fork(
         self,
@@ -273,13 +275,15 @@ class CircularDataQueue(DataQueue):
         super().put_nowait(item)
 
     @t.overload
-    def fork(self, queue_type: None) -> CircularDataQueue: ...
+    def fork(self, queue_type: None) -> CircularDataQueue:
+        ...
 
     @t.overload
     def fork(
         self,
         queue_type: type[QueueProtocol],
-    ) -> QueueProtocol: ...
+    ) -> QueueProtocol:
+        ...
 
     def fork(
         self,
@@ -347,13 +351,15 @@ class DistinctConsecutiveDataQueue(DataQueue):
             self._last_value = item
 
     @t.overload
-    def fork(self, queue_type: None) -> CircularDataQueue: ...
+    def fork(self, queue_type: None) -> CircularDataQueue:
+        ...
 
     @t.overload
     def fork(
         self,
         queue_type: type[QueueProtocol],
-    ) -> QueueProtocol: ...
+    ) -> QueueProtocol:
+        ...
 
     def fork(
         self,
@@ -411,7 +417,8 @@ class StreamingHandle(ABC):
         self,
         *,
         parser_callback: t.Callable[[AnnotatedValue], AnnotatedValue] | None = None,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     @abstractmethod
     def register_data_queue(

--- a/src/labone/mock/automatic_session_functionality.py
+++ b/src/labone/mock/automatic_session_functionality.py
@@ -205,7 +205,8 @@ class AutomaticSessionFunctionality(SessionMockFunctionality):
     async def get_with_expression(
         self,
         path_expression: LabOneNodePath,
-        flags: ListNodesFlags | int = ListNodesFlags.ABSOLUTE  # noqa: ARG002
+        flags: ListNodesFlags  # noqa: ARG002
+        | int = ListNodesFlags.ABSOLUTE
         | ListNodesFlags.RECURSIVE
         | ListNodesFlags.LEAVES_ONLY
         | ListNodesFlags.EXCLUDE_STREAMING

--- a/src/labone/mock/session_mock_template.py
+++ b/src/labone/mock/session_mock_template.py
@@ -121,7 +121,8 @@ class SessionMockFunctionality(ABC):
     async def get_with_expression(
         self,
         path_expression: LabOneNodePath,
-        flags: ListNodesFlags | int = ListNodesFlags.ABSOLUTE
+        flags: ListNodesFlags
+        | int = ListNodesFlags.ABSOLUTE
         | ListNodesFlags.RECURSIVE
         | ListNodesFlags.LEAVES_ONLY
         | ListNodesFlags.EXCLUDE_STREAMING

--- a/src/labone/nodetree/enum.py
+++ b/src/labone/nodetree/enum.py
@@ -81,7 +81,8 @@ class NodeEnum(IntEnum):
     """
 
     # Required for typing
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        ...
 
     # Required for typing
     def __call__(self, *args, **kwargs) -> None:  # noqa: D102

--- a/src/labone/nodetree/helper.py
+++ b/src/labone/nodetree/helper.py
@@ -31,10 +31,12 @@ TreeProp = t.Dict[LabOneNodePath, T]
 class NestedDict(t.Protocol[T]):  # type: ignore[misc]
     """Protocol representing a nested dictionary structure."""
 
-    def __getitem__(self, key: str) -> T | NestedDict[T]: ...
+    def __getitem__(self, key: str) -> T | NestedDict[T]:
+        ...
 
     # retyping dict method, because inheriting from non-protocal is prohibited
-    def __setitem__(self, key: str, item: T | NestedDict) -> None: ...
+    def __setitem__(self, key: str, item: T | NestedDict) -> None:
+        ...
 
     def keys(self) -> t.KeysView[str]:
         """..."""
@@ -94,7 +96,8 @@ class Session(t.Protocol):
     async def get_with_expression(
         self,
         path_expression: LabOneNodePath,
-        flags: ListNodesFlags | int = ListNodesFlags.ABSOLUTE
+        flags: ListNodesFlags
+        | int = ListNodesFlags.ABSOLUTE
         | ListNodesFlags.RECURSIVE
         | ListNodesFlags.LEAVES_ONLY
         | ListNodesFlags.EXCLUDE_STREAMING

--- a/src/labone/nodetree/node.py
+++ b/src/labone/nodetree/node.py
@@ -75,7 +75,12 @@ class NodeTreeManager:
     ):
         self._session = session
         self.path_to_info = path_to_info
-        self._parser = parser
+
+        def make_path_lower(ann: AnnotatedValue)->AnnotatedValue:
+            ann.path = ann.path.lower()
+            return ann
+
+        self._parser = lambda ann: parser(make_path_lower(ann))
         self._hide_kernel_prefix = hide_kernel_prefix
 
         self._remembered_nodes: dict[tuple[NormalizedPathSegment, ...], Node] = {}
@@ -114,6 +119,9 @@ class NodeTreeManager:
             path_to_info: Describing the new paths and the associated
                 information.
         """
+        # make all paths lower
+        path_to_info = {path.lower(): info for path, info in path_to_info.items()}
+
         # dict prevents duplicates
         self.path_to_info.update(path_to_info)
 
@@ -918,13 +926,15 @@ class Node(MetaNode, ABC):
     @abstractmethod
     async def _get(
         self,
-    ) -> AnnotatedValue | ResultNode: ...
+    ) -> AnnotatedValue | ResultNode:
+        ...
 
     @abstractmethod
     async def _set(
         self,
         value: Value,
-    ) -> AnnotatedValue | ResultNode: ...
+    ) -> AnnotatedValue | ResultNode:
+        ...
 
     @classmethod
     def build(
@@ -1015,7 +1025,8 @@ class Node(MetaNode, ABC):
         ...
 
     @t.overload
-    async def subscribe(self, *, get_initial_value: bool = False) -> DataQueue: ...
+    async def subscribe(self, *, get_initial_value: bool = False) -> DataQueue:
+        ...
 
     @t.overload
     async def subscribe(
@@ -1023,7 +1034,8 @@ class Node(MetaNode, ABC):
         *,
         queue_type: type[QueueProtocol],
         get_initial_value: bool = False,
-    ) -> QueueProtocol: ...
+    ) -> QueueProtocol:
+        ...
 
     @abstractmethod
     async def subscribe(
@@ -1155,7 +1167,8 @@ class LeafNode(Node):
         raise LabOneInvalidPathError(msg)
 
     @t.overload
-    async def subscribe(self, *, get_initial_value: bool = False) -> DataQueue: ...
+    async def subscribe(self, *, get_initial_value: bool = False) -> DataQueue:
+        ...
 
     @t.overload
     async def subscribe(
@@ -1163,7 +1176,8 @@ class LeafNode(Node):
         *,
         queue_type: type[QueueProtocol],
         get_initial_value: bool = False,
-    ) -> QueueProtocol: ...
+    ) -> QueueProtocol:
+        ...
 
     async def subscribe(
         self,
@@ -1339,7 +1353,8 @@ class WildcardOrPartialNode(Node, ABC):
         self,
         *,
         get_initial_value: bool = False,
-    ) -> DataQueue: ...
+    ) -> DataQueue:
+        ...
 
     @t.overload
     async def subscribe(
@@ -1347,7 +1362,8 @@ class WildcardOrPartialNode(Node, ABC):
         *,
         queue_type: type[QueueProtocol],
         get_initial_value: bool = False,
-    ) -> QueueProtocol: ...
+    ) -> QueueProtocol:
+        ...
 
     async def subscribe(
         self,


### PR DESCRIPTION
Some devices send paths in lower format, some in upper format, and sometimes it depends on the method called. This lead to a problem in finding the right enums for a get request, if the cases didnt match. To avoid such situations in the future, we should make sure all paths are in one format (lower case).