### PR TITLE
Tobiasa/no capnp request

### DIFF
--- a/src/labone/mock/entry_point.py
+++ b/src/labone/mock/entry_point.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from labone.core.helper import CapnpLock, create_lock
 from labone.core.reflection.server import ReflectionServer
 from labone.core.session import Session
 from labone.mock.hpk_schema import get_schema
@@ -30,6 +31,7 @@ class MockSession(Session):
         mock_server: Mock server.
         capnp_session: Capnp session.
         reflection: Reflection server.
+        capnp_lock: Capnp lock.
     """
 
     def __init__(
@@ -38,8 +40,13 @@ class MockSession(Session):
         capnp_session: CapnpCapability,
         *,
         reflection: ReflectionServer,
+        capnp_lock: CapnpLock,
     ):
-        super().__init__(capnp_session, reflection_server=reflection)
+        super().__init__(
+            capnp_session,
+            reflection_server=reflection,
+            capnp_lock=capnp_lock,
+        )
         self._mock_server = mock_server
 
 
@@ -71,8 +78,10 @@ async def spawn_hpk_mock(
         mock=SessionMockTemplate(functionality),
     )
     reflection = await ReflectionServer.create_from_connection(client)
+    capnp_lock = await create_lock()
     return MockSession(
         server,
         reflection.session,  # type: ignore[attr-defined]
         reflection=reflection,
+        capnp_lock=capnp_lock,
     )

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,8 +1,8 @@
 from typing import Any
 
-import capnp
 import pytest
 import pytest_asyncio
+from labone.core.helper import LoopManager
 
 from .resources import (
     error_capnp,
@@ -21,8 +21,11 @@ async def kj_loop():
     Its important that every test creates and closes the kj_event loop.
     This helps to avoid leaking errors and promises from one test to another.
     """
-    async with capnp.kj_loop():
+    loop_manager = await LoopManager.create()
+    try:
         yield
+    finally:
+        await loop_manager.destroy()
 
 
 class MockReflectionServer:

--- a/tests/core/test_create_session.py
+++ b/tests/core/test_create_session.py
@@ -7,7 +7,6 @@ from labone.core import connection_layer, kernel_session
 from labone.core.errors import LabOneCoreError, UnavailableError
 
 
-@patch("labone.core.session._send_and_wait_request", autospec=True)
 @patch("labone.core.kernel_session.create_session_client_stream", autospec=True)
 @patch("labone.core.kernel_session.capnp", autospec=True)
 @patch("labone.core.kernel_session.ReflectionServer", autospec=True)
@@ -16,7 +15,6 @@ async def test_session_create_ok_zi(
     reflection_server,
     capnp_mock,
     create_session_client_stream,
-    send_request,
 ):
     dummy_sock = MagicMock()
     dummy_kernel_info_extended = MagicMock()
@@ -26,7 +24,8 @@ async def test_session_create_ok_zi(
         dummy_kernel_info_extended,
         dummy_server_info_extended,
     )
-    send_request.return_value.version = str(
+    mock_session = reflection_server.create_from_connection.return_value.session
+    mock_session.capnp_capability.getSessionVersion.return_value.version = str(
         kernel_session.KernelSession.TESTED_CAPABILITY_VERSION,
     )
     capnp_mock.AsyncIoStream.create_connection = AsyncMock()

--- a/tests/core/test_kj_event_loop.py
+++ b/tests/core/test_kj_event_loop.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import labone.core.helper
 import pytest
 import pytest_asyncio
+from labone.core.errors import LabOneCoreError, UnavailableError
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -28,3 +29,41 @@ def test_event_loop_exit_ok(capnp):
     asyncio.run(labone.core.helper.ensure_capnp_event_loop())
     capnp.kj_loop().__aenter__.assert_called_once()
     capnp.kj_loop().__aexit__.assert_called_once()
+
+
+@pytest.mark.asyncio()
+async def test_destroy_lock_ok():
+    lock = await labone.core.helper.create_lock()
+    await lock.destroy()
+    with pytest.raises(UnavailableError):
+        async with lock.lock():
+            assert False  # noqa: PT015, B011
+
+
+@pytest.mark.asyncio()
+async def test_destroy_lock_multiple_times_ok():
+    lock = await labone.core.helper.create_lock()
+    await lock.destroy()
+    await lock.destroy()
+    with pytest.raises(UnavailableError):
+        async with lock.lock():
+            assert False  # noqa: PT015, B011
+
+
+@pytest.mark.asyncio()
+async def test_multiple_loop_manager_fails():
+    loop_manager = await labone.core.helper.LoopManager.create()
+    try:
+        with pytest.raises(LabOneCoreError):
+            await labone.core.helper.LoopManager.create()
+    finally:
+        await loop_manager.destroy()
+
+
+@pytest.mark.asyncio()
+async def test_destroy_loop_manager_multiple_times_ok():
+    loop_manager = await labone.core.helper.LoopManager.create()
+    await loop_manager.destroy()
+    await loop_manager.destroy()
+    with pytest.raises(UnavailableError):
+        await loop_manager.create_lock()


### PR DESCRIPTION
This PR includes the following changes to improve the stability when exceptions are raised by pycapnp within RPC calls. 

* hiding the capnp stacktrace from exceptions (this should not be necessary but it does not hurt ... the c++ trace is anyway not included)
* adding the loop manager and locks to prevent that rpc calls can be made without the kj eventloop running. (+ the loop can not be closed when a rpc call is in progress)
* do not use request objects in our core but use plain function calls to avoid having c++ references in the python code