### PR TITLE
Add basic parsing capability for streaming errors

### DIFF
--- a/src/labone/core/session.py
+++ b/src/labone/core/session.py
@@ -221,7 +221,7 @@ class Session:
     # The minimum capability version that is required by the labone api.
     MIN_CAPABILITY_VERSION = version.Version("1.7.0")
     # The latest known version of the capability version.
-    TESTED_CAPABILITY_VERSION = version.Version("1.7.0")
+    TESTED_CAPABILITY_VERSION = version.Version("1.9.0")
 
     def __init__(
         self,

--- a/src/labone/core/subscription.py
+++ b/src/labone/core/subscription.py
@@ -564,7 +564,14 @@ def streaming_handle_factory(
             """
             try:
                 parsed_value = self._parser_callback(AnnotatedValue.from_capnp(value))
+            except errors.LabOneCoreError as err:  # pragma: no cover
+                logger.exception(err.args[0])
             except ValueError as err:  # pragma: no cover
+                self._data_queues = [
+                    data_queue().disconnect()  # type: ignore[union-attr] # supposed to throw
+                    for data_queue in self._data_queues
+                    if data_queue() is not None
+                ]
                 logger.error(  # noqa: TRY400
                     "Disconnecting subscription. Could not parse value.  Error: %s",
                     err.args[0],

--- a/src/labone/core/value.py
+++ b/src/labone/core/value.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 import capnp
 import numpy as np
 
-from labone.core.errors import SHFHeaderVersionNotSupportedError
+from labone.core.errors import SHFHeaderVersionNotSupportedError, error_from_capnp
 from labone.core.helper import (
     LabOneNodePath,
     VectorElementType,
@@ -276,6 +276,7 @@ def _capnp_value_to_python_value(
 
     Raises:
         ValueError: If the capnp value has an unknown type or can not be parsed.
+        LabOneCoreError: If the capnp value is a streaming error.
     """
     capnp_type = capnp_value.which()
     if capnp_type == "int64":
@@ -294,6 +295,8 @@ def _capnp_value_to_python_value(
         return TriggerSample.from_capnp(capnp_value.triggerSample), None
     if capnp_type == "none":
         return None, None
+    if capnp_type == "streamingError":
+        raise error_from_capnp(capnp_value.streamingError)
     msg = f"Unknown capnp type: {capnp_type}"
     raise ValueError(msg)
 

--- a/tests/core/resources/value.capnp
+++ b/tests/core/resources/value.capnp
@@ -6,6 +6,12 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("zhinst_capnp");
 
 using import "path.capnp".Path;
+using import "error.capnp".Error;
+
+# StreamingErrors are used to signal errors within a continuous stream of data.
+# Outside of the streaming context, the must not occur but rather be signaled
+# using the result error mechanism.
+using StreamingError = Error;
 
 struct Void { }
 
@@ -60,6 +66,7 @@ struct Value @0xb1838b4771be75ac {
     cntSample     @5 :CntSample;
     triggerSample @6 :TriggerSample;
     none          @7 :Void;
+    streamingError @8 :StreamingError;
   }
 }
 

--- a/tests/core/test_annotated_value_from_capnp.py
+++ b/tests/core/test_annotated_value_from_capnp.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import labone.core.value as value_module
 import numpy as np
 import pytest
+from labone.core.errors import LabOneCoreError
 
 from .resources import value_capnp
 
@@ -103,6 +104,25 @@ def test_cnt_sample():
     assert parsed_value.value.timestamp == input_dict["value"]["cntSample"]["timestamp"]
     assert parsed_value.value.counter == input_dict["value"]["cntSample"]["counter"]
     assert parsed_value.value.trigger == input_dict["value"]["cntSample"]["trigger"]
+
+
+def test_streaming_error():
+    input_dict = {
+        "metadata": {"timestamp": 42, "path": "/non/of/your/business"},
+        "value": {
+            "streamingError": {
+                "code": 1,
+                "message": "Test message",
+                "category": "zi:test",
+                "kind": "timeout",
+                "source": "",
+            },
+        },
+    }
+    msg = value_capnp.AnnotatedValue.new_message()
+    msg.from_dict(input_dict)
+    with pytest.raises(LabOneCoreError):
+        value_module.AnnotatedValue.from_capnp(msg)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This commit allows the parsing of streaming error. These errors are transported through an AnnotatedValue within the subcriptions.

For now the exceptions are simply logged. Once we know how we want to report the errors this subscription needes to be adapted.