### PR TITLE
Make the capnp server classes available

### DIFF
--- a/src/labone/__init__.py
+++ b/src/labone/__init__.py
@@ -4,5 +4,12 @@ from labone._version import __version__  # type: ignore[import]
 from labone.core import ListNodesFlags
 from labone.dataserver import DataServer
 from labone.instrument import Instrument
+from labone.server.session import SessionFunctionality
 
-__all__ = ["__version__", "Instrument", "DataServer", "ListNodesFlags"]
+__all__ = [
+    "__version__",
+    "Instrument",
+    "DataServer",
+    "ListNodesFlags",
+    "SessionFunctionality",
+]

--- a/src/labone/mock/__init__.py
+++ b/src/labone/mock/__init__.py
@@ -18,10 +18,8 @@ Example:
 
 from labone.mock.automatic_session_functionality import AutomaticSessionFunctionality
 from labone.mock.entry_point import spawn_hpk_mock
-from labone.mock.session_mock_template import SessionMockFunctionality
 
 __all__ = [
     "spawn_hpk_mock",
     "AutomaticSessionFunctionality",
-    "SessionMockFunctionality",
 ]

--- a/src/labone/mock/automatic_session_functionality.py
+++ b/src/labone/mock/automatic_session_functionality.py
@@ -42,8 +42,8 @@ from labone.core.value import (
     Value,
 )
 from labone.mock.errors import LabOneMockError
-from labone.mock.session_mock_template import SessionMockFunctionality, Subscription
 from labone.node_info import NodeInfo
+from labone.server.session import SessionFunctionality, Subscription
 
 if t.TYPE_CHECKING:
     from labone.core.helper import LabOneNodePath
@@ -59,7 +59,7 @@ class PathData:
     streaming_handles: list[Subscription]
 
 
-class AutomaticSessionFunctionality(SessionMockFunctionality):
+class AutomaticSessionFunctionality(SessionFunctionality):
     """Predefined behaviour for HPK mock.
 
     Args:

--- a/src/labone/mock/entry_point.py
+++ b/src/labone/mock/entry_point.py
@@ -7,14 +7,14 @@ from typing import TYPE_CHECKING
 from labone.core.reflection.server import ReflectionServer
 from labone.core.session import Session
 from labone.mock.hpk_schema import get_schema
-from labone.mock.mock_server import start_local_mock
-from labone.mock.session_mock_template import SessionMockTemplate
+from labone.server.server import start_local_server
+from labone.server.session import SessionInterface
 
 if TYPE_CHECKING:
     import capnp
 
     from labone.core.helper import CapnpCapability
-    from labone.mock.session_mock_template import SessionMockFunctionality
+    from labone.server.session import SessionFunctionality
 
 
 class MockSession(Session):
@@ -44,7 +44,7 @@ class MockSession(Session):
 
 
 async def spawn_hpk_mock(
-    functionality: SessionMockFunctionality,
+    functionality: SessionFunctionality,
 ) -> MockSession:
     """Shortcut for creating a mock server.
 
@@ -66,9 +66,9 @@ async def spawn_hpk_mock(
         capnp.lib.capnp.KjException: If the schema is invalid. Or the id
             of the concrete server is not in the schema.
     """
-    server, client = await start_local_mock(
+    server, client = await start_local_server(
         schema=get_schema(),
-        mock=SessionMockTemplate(functionality),
+        server=SessionInterface(functionality),
     )
     reflection = await ReflectionServer.create_from_connection(client)
     return MockSession(

--- a/src/labone/server/__init__.py
+++ b/src/labone/server/__init__.py
@@ -3,7 +3,7 @@
 This subpackage allows to create a data server through capnp.
 """
 
-from labone.server.server import CapnpServer
+from labone.server.server import CapnpServer, start_server
 from labone.server.session import (
     SessionFunctionality,
     SessionInterface,
@@ -12,6 +12,7 @@ from labone.server.session import (
 
 __all__ = [
     "CapnpServer",
+    "start_server",
     "SessionFunctionality",
     "SessionInterface",
     "Subscription",

--- a/src/labone/server/__init__.py
+++ b/src/labone/server/__init__.py
@@ -1,0 +1,18 @@
+"""Subpackage for the server functionality of the LabOne API.
+
+This subpackage allows to create a data server through capnp.
+"""
+
+from labone.server.server import CapnpServer
+from labone.server.session import (
+    SessionFunctionality,
+    SessionInterface,
+    Subscription,
+)
+
+__all__ = [
+    "CapnpServer",
+    "SessionFunctionality",
+    "SessionInterface",
+    "Subscription",
+]

--- a/src/labone/server/session.py
+++ b/src/labone/server/session.py
@@ -1,10 +1,10 @@
-"""Hpk Mock Server method definitions.
+"""Capnp Server method definitions.
 
-This module contains the method definitions for the Hpk Mock Server,
+This module contains the method definitions for the Capnp Server,
 including setting and getting values, listing nodes, and subscribing to
 nodes. This specific capnp server methods define the specific
 Hpk behavior.
-The logic of the capnp methods is deligated to the HpkMockFunctionality class,
+The logic of the capnp methods is deligated to the SessionFunctionality class,
 which offers a blueprint meant to be overriden by the user.
 """
 
@@ -21,7 +21,7 @@ from labone.core.value import (
     _capnp_value_to_python_value,
     value_from_python_types_dict,
 )
-from labone.mock.mock_server import ServerTemplate
+from labone.server.server import CapnpServer
 
 if TYPE_CHECKING:
     from capnp.lib.capnp import (
@@ -86,22 +86,22 @@ class Subscription:
         return self._path
 
 
-class SessionMockFunctionality(ABC):
-    """Hpk blueprint for defining mock server behavior.
+class SessionFunctionality(ABC):
+    """Blueprint for defining the session behavior.
 
-    The HpKMockFunctionality class offers a interface between
+    The SessionFunctionality class offers a interface between
     capnp server logic and the user. The user can override the methods
-    to define an individual mock server. The signature of the methods
+    to define an individual server. The signature of the methods
     is mostly identical to the session-interface on the caller side.
     Thereby it feels as if the session-interface is overritten directly,
     hiding the capnp server logic from the user.
 
     Two possible ways to use this class arise:
      * Call methods indirectly (via capnp server), by having a session
-       to a mock server.
+       to a server.
      * Call methods directly. This can be used to manipulate the state
        internally. Limitations of what can be set to a server are
-       bypassed. E.g. can be useful when setting shf vector nodes.
+       bypassed. E.g. can be useful when setting SHF vector nodes.
 
     Both approaches can be combined.
     """
@@ -234,26 +234,26 @@ def build_capnp_error(error: Exception) -> _DynamicStructBuilder:
     }
 
 
-class SessionMockTemplate(ServerTemplate):
-    """Hpk Mock Server.
+class SessionInterface(CapnpServer):
+    """Capnp session interface.
 
     The logic for answering capnp requests is outsourced and taken as an argument.
-    This allows for custom mock server definition while keeping this classes
+    This allows for custom server definition while keeping this classes
     code static.
 
     Note:
         Methods within serve for capnp to answer requests. They should not be
         called directly. They should not be overritten in order to define
-        custom behavior. Instead, override the methods of HpkMockFunctionality.
+        custom behavior. Instead, override the methods of SessionFunctionality.
 
     Args:
-        functionality: The implementation of the mock server behavior.
+        functionality: The implementation of the server behavior.
     """
 
     server_id = HPK_SCHEMA_ID
     type_id = SESSION_SCHEMA_ID
 
-    def __init__(self, functionality: SessionMockFunctionality) -> None:
+    def __init__(self, functionality: SessionFunctionality) -> None:
         self._functionality = functionality
 
     async def getSessionVersion(  # noqa: N802
@@ -431,7 +431,7 @@ class SessionMockTemplate(ServerTemplate):
         """Capnp server method to subscribe to nodes.
 
         Do not override this method. Instead, override 'subscribe_logic'
-        of HpkMockFunctionality (or subclass).
+        of SessionFunctionality (or subclass).
 
         Args:
             subscription: Capnp object containing information on

--- a/tests/core/test_session.py
+++ b/tests/core/test_session.py
@@ -32,8 +32,8 @@ from labone.core.value import AnnotatedValue
 from labone.mock import AutomaticSessionFunctionality, spawn_hpk_mock
 from labone.mock.entry_point import MockSession
 from labone.mock.hpk_schema import get_schema
-from labone.mock.mock_server import start_local_mock
-from labone.mock.session_mock_template import SessionMockTemplate
+from labone.server.server import start_local_server
+from labone.server.session import SessionInterface
 
 from .resources import session_protocol_capnp, testfile_capnp, value_capnp
 
@@ -954,7 +954,7 @@ async def test_set_transaction_mix_multiple_devices():
     assert (await session_b.get("a")).value == 2
 
 
-class DummyServerVersionTest(SessionMockTemplate):
+class DummyServerVersionTest(SessionInterface):
     def __init__(self, version: str):
         super().__init__(None)
         self._version = version
@@ -975,9 +975,9 @@ class DummyServerVersionTest(SessionMockTemplate):
 )
 @pytest.mark.asyncio()
 async def test_ensure_compatibility_mismatch(version, should_fail):
-    mock_server, client_connection = await start_local_mock(
+    mock_server, client_connection = await start_local_server(
         schema=get_schema(),
-        mock=DummyServerVersionTest(version),
+        server=DummyServerVersionTest(version),
     )
     reflection = await ReflectionServer.create_from_connection(client_connection)
     session = MockSession(

--- a/tests/mock/test_session_mock_template.py
+++ b/tests/mock/test_session_mock_template.py
@@ -15,12 +15,12 @@ import pytest
 from labone.core.session import ListNodesFlags
 from labone.core.value import AnnotatedValue
 from labone.mock.entry_point import spawn_hpk_mock
-from labone.mock.session_mock_template import SessionMockFunctionality
+from labone.server.session import SessionFunctionality
 
 
 @pytest.mark.asyncio()
 async def test_set_propagates_to_functionality_and_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.set.return_value = AnnotatedValue(
         path="/mock/path",
         value=1,
@@ -40,7 +40,7 @@ async def test_set_propagates_to_functionality_and_back():
 
 @pytest.mark.asyncio()
 async def test_get_propagates_to_functionality_and_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.get.return_value = AnnotatedValue(
         path="/mock/path",
         value=1,
@@ -60,7 +60,7 @@ async def test_get_propagates_to_functionality_and_back():
 
 @pytest.mark.asyncio()
 async def test_get_with_expression_propagates_to_functionality_and_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.get_with_expression.return_value = [
         AnnotatedValue(path="/mock/path", value=1, timestamp=2),
         AnnotatedValue(path="/mock/path/2", value=3, timestamp=4),
@@ -82,7 +82,7 @@ async def test_get_with_expression_propagates_to_functionality_and_back():
 
 @pytest.mark.asyncio()
 async def test_set_with_expression_propagates_to_functionality_and_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.set_with_expression.return_value = [
         AnnotatedValue(path="/mock/path", value=1, timestamp=2),
         AnnotatedValue(path="/mock/path/2", value=1, timestamp=4),
@@ -106,7 +106,7 @@ async def test_set_with_expression_propagates_to_functionality_and_back():
 
 @pytest.mark.asyncio()
 async def test_subscribe_propagates_to_functionality():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
 
     session = await spawn_hpk_mock(functionality)
 
@@ -118,7 +118,7 @@ async def test_subscribe_propagates_to_functionality():
 
 @pytest.mark.asyncio()
 async def test_list_nodes_propagates_to_functionality_and_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.list_nodes.return_value = ["/a/b", "/a/c"]
 
     session = await spawn_hpk_mock(functionality)
@@ -137,7 +137,7 @@ async def test_list_nodes_propagates_to_functionality_and_back():
 
 @pytest.mark.asyncio()
 async def test_list_nodes_info_propagates_to_functionality_and_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.list_nodes_info.return_value = {
         "/a/b": {"value": 1},
         "/a/c": {"value": 2},
@@ -162,7 +162,7 @@ async def test_list_nodes_info_propagates_to_functionality_and_back():
 
 @pytest.mark.asyncio()
 async def test_errors_in_set_functionality_are_transmitted_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.set.side_effect = Exception("Some error")
 
     session = await spawn_hpk_mock(functionality)
@@ -173,7 +173,7 @@ async def test_errors_in_set_functionality_are_transmitted_back():
 
 @pytest.mark.asyncio()
 async def test_errors_in_get_functionality_are_transmitted_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.get.side_effect = Exception("Some error")
 
     session = await spawn_hpk_mock(functionality)
@@ -184,7 +184,7 @@ async def test_errors_in_get_functionality_are_transmitted_back():
 
 @pytest.mark.asyncio()
 async def test_errors_in_get_with_expression_functionality_are_transmitted_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.get_with_expression.side_effect = Exception("Some error")
 
     session = await spawn_hpk_mock(functionality)
@@ -195,7 +195,7 @@ async def test_errors_in_get_with_expression_functionality_are_transmitted_back(
 
 @pytest.mark.asyncio()
 async def test_errors_in_set_with_expression_functionality_are_transmitted_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.set_with_expression.side_effect = Exception("Some error")
 
     session = await spawn_hpk_mock(functionality)
@@ -206,7 +206,7 @@ async def test_errors_in_set_with_expression_functionality_are_transmitted_back(
 
 @pytest.mark.asyncio()
 async def test_errors_in_subscribe_functionality_are_transmitted_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.subscribe_logic.side_effect = Exception("Some error")
 
     session = await spawn_hpk_mock(functionality)
@@ -217,7 +217,7 @@ async def test_errors_in_subscribe_functionality_are_transmitted_back():
 
 @pytest.mark.asyncio()
 async def test_errors_in_list_nodes_functionality_are_transmitted_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.list_nodes.side_effect = Exception("Some error")
 
     session = await spawn_hpk_mock(functionality)
@@ -228,7 +228,7 @@ async def test_errors_in_list_nodes_functionality_are_transmitted_back():
 
 @pytest.mark.asyncio()
 async def test_errors_in_list_nodes_info_functionality_are_transmitted_back():
-    functionality = Mock(spec=SessionMockFunctionality)
+    functionality = Mock(spec=SessionFunctionality)
     functionality.list_nodes_info.side_effect = Exception("Some error")
 
     session = await spawn_hpk_mock(functionality)


### PR DESCRIPTION
Move code used for mocking the device server to its own module `labone.server` to make it reusable for the Python capnp servers. Remove the mention of "mock" in the exported code.