### PR TITLE
Fix invalid import sorting in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ all = ["style", "typing"]
 target-version = ["py38"]
 
 [tool.ruff]
+src = ["src", "tests"]
 target-version = "py38"
 select = ["ALL"]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 dependencies = [
   "black>=23.1.0",
   "mypy>=1.0.0",
-  "ruff>=0.0.243",
+  "ruff>=0.4.0",
   "numpy>=1.20",
   "asyncio-atexit==1.0.1",
 ]
@@ -100,6 +100,8 @@ target-version = ["py38"]
 [tool.ruff]
 src = ["src", "tests"]
 target-version = "py38"
+
+[tool.ruff.lint]
 select = ["ALL"]
 ignore = [
   # Type annotation for self
@@ -120,23 +122,23 @@ ignore = [
   "ANN204",
 ]
 
-[tool.ruff.flake8-annotations]
+[tool.ruff.lint.flake8-annotations]
 mypy-init-return = true
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 # Flag errors (`C901`) whenever the complexity level exceeds 15.
 max-complexity = 15
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-third-party = ["capnp"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = [
   "PLR2004",

--- a/tests/core/test_annotated_value_from_capnp.py
+++ b/tests/core/test_annotated_value_from_capnp.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import patch
 
-import labone.core.value as value_module
 import numpy as np
 import pytest
+
+import labone.core.value as value_module
 from labone.core.errors import LabOneCoreError
 
 from .resources import value_capnp

--- a/tests/core/test_annotated_value_to_capnp.py
+++ b/tests/core/test_annotated_value_to_capnp.py
@@ -10,6 +10,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
+
 from labone.core.helper import VectorElementType
 from labone.core.shf_vector_data import (
     VectorValueType,

--- a/tests/core/test_connection_layer.py
+++ b/tests/core/test_connection_layer.py
@@ -5,8 +5,9 @@ import socket
 from unittest.mock import patch
 
 import pytest
-from labone.core import connection_layer, errors
 from packaging import version
+
+from labone.core import connection_layer, errors
 
 from .resources import hello_msg_capnp, orchestrator_capnp
 

--- a/tests/core/test_create_session.py
+++ b/tests/core/test_create_session.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from labone.core import connection_layer, kernel_session
 from labone.core.errors import LabOneCoreError, UnavailableError
 

--- a/tests/core/test_kj_event_loop.py
+++ b/tests/core/test_kj_event_loop.py
@@ -1,9 +1,10 @@
 import asyncio
 from unittest.mock import patch
 
-import labone.core.helper
 import pytest
 import pytest_asyncio
+
+import labone.core.helper
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/core/test_reflection_server.py
+++ b/tests/core/test_reflection_server.py
@@ -1,8 +1,9 @@
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import capnp
-import labone.core.reflection.server as reflection_server
 import pytest
+
+import labone.core.reflection.server as reflection_server
 from labone.core.errors import LabOneCoreError
 
 

--- a/tests/core/test_reflection_type_system.py
+++ b/tests/core/test_reflection_type_system.py
@@ -7,6 +7,7 @@ from capnp.lib.capnp import (
     _InterfaceModule,
     _StructModule,
 )
+
 from labone.core.reflection import capnp_dynamic_type_system
 from labone.core.reflection.parsed_wire_schema import LoadedNode
 

--- a/tests/core/test_result.py
+++ b/tests/core/test_result.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import capnp
 import pytest
+
 from labone.core import errors
 from labone.core.result import unwrap
 

--- a/tests/core/test_session.py
+++ b/tests/core/test_session.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 import capnp
 import pytest
 import pytest_asyncio
+
 from labone.core import errors
 from labone.core.connection_layer import ServerInfo, ZIKernelInfo
 from labone.core.helper import request_field_type_description

--- a/tests/core/test_shf_vector_data.py
+++ b/tests/core/test_shf_vector_data.py
@@ -2,6 +2,7 @@ import struct
 
 import numpy as np
 import pytest
+
 from labone.core.shf_vector_data import (
     SHFDemodSample,
     ShfDemodulatorVectorExtraHeader,

--- a/tests/core/test_subscription.py
+++ b/tests/core/test_subscription.py
@@ -4,6 +4,7 @@ import asyncio
 
 import capnp
 import pytest
+
 from labone.core import errors
 from labone.core.subscription import (
     CircularDataQueue,

--- a/tests/mock/ab_hpk_automatic_functionality_test.py
+++ b/tests/mock/ab_hpk_automatic_functionality_test.py
@@ -21,6 +21,7 @@ import io
 from contextlib import redirect_stdout
 
 import pytest
+
 from labone.core import AnnotatedValue, KernelSession, ServerInfo, ZIKernelInfo
 from labone.core.session import ListNodesFlags, Session
 from labone.mock import spawn_hpk_mock

--- a/tests/mock/module_test.py
+++ b/tests/mock/module_test.py
@@ -11,6 +11,7 @@ we still need to use a larger scope in order to test meaningful behavior.
 
 import numpy as np
 import pytest
+
 from labone.core import AnnotatedValue
 from labone.core.shf_vector_data import (
     SHFDemodSample,

--- a/tests/mock/test_automatic_mock_functionality.py
+++ b/tests/mock/test_automatic_mock_functionality.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+
 from labone.core.errors import LabOneCoreError
 
 if TYPE_CHECKING:

--- a/tests/mock/test_session_mock_template.py
+++ b/tests/mock/test_session_mock_template.py
@@ -12,6 +12,7 @@ server mock are compatible and work as a functional unit.
 from unittest.mock import ANY, Mock
 
 import pytest
+
 from labone.core.session import ListNodesFlags
 from labone.core.value import AnnotatedValue
 from labone.mock.entry_point import spawn_hpk_mock

--- a/tests/nodetree/test_node_functional.py
+++ b/tests/nodetree/test_node_functional.py
@@ -12,7 +12,6 @@ if t.TYPE_CHECKING:
     from labone.core.value import AnnotatedValue
 from labone.nodetree.enum import _get_enum
 from labone.nodetree.errors import LabOneInvalidPathError
-
 from tests.mock_server_for_testing import get_mocked_node, get_unittest_mocked_node
 
 
@@ -148,7 +147,7 @@ async def test_contains_subnode():
 @pytest.mark.asyncio()
 async def test_node_does_not_contain_itself():
     node = await get_unittest_mocked_node({"/a/b": {}})
-    assert node not in node  # noqa: PLR0124
+    assert node not in node
 
 
 @pytest.mark.asyncio()

--- a/tests/nodetree/test_node_functional.py
+++ b/tests/nodetree/test_node_functional.py
@@ -147,7 +147,7 @@ async def test_contains_subnode():
 @pytest.mark.asyncio()
 async def test_node_does_not_contain_itself():
     node = await get_unittest_mocked_node({"/a/b": {}})
-    assert node not in node
+    assert node not in node  # noqa: PLR0124
 
 
 @pytest.mark.asyncio()

--- a/tests/nodetree/test_node_info.py
+++ b/tests/nodetree/test_node_info.py
@@ -7,8 +7,8 @@ customers.
 from __future__ import annotations
 
 import pytest
-from labone.node_info import NodeInfo, OptionInfo
 
+from labone.node_info import NodeInfo, OptionInfo
 from tests.mock_server_for_testing import get_unittest_mocked_node
 
 

--- a/tests/nodetree/test_node_to_session_interface.py
+++ b/tests/nodetree/test_node_to_session_interface.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from unittest.mock import ANY, Mock
 
 import pytest
+
 from labone.core.session import Session
 from labone.core.value import AnnotatedValue
 from labone.nodetree.entry_point import construct_nodetree

--- a/tests/nodetree/test_result_node.py
+++ b/tests/nodetree/test_result_node.py
@@ -1,7 +1,7 @@
 import pytest
+
 from labone.core.value import AnnotatedValue
 from labone.nodetree.errors import LabOneInvalidPathError
-
 from tests.mock_server_for_testing import get_mocked_node
 
 

--- a/tests/nodetree/test_split_join_path.py
+++ b/tests/nodetree/test_split_join_path.py
@@ -1,4 +1,5 @@
 import pytest
+
 from labone.nodetree.helper import join_path, split_path
 
 

--- a/tests/test_dataserver.py
+++ b/tests/test_dataserver.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from labone.core import (
     KernelSession,
 )

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,10 +1,10 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from labone.errors import LabOneError
 from labone.instrument import Instrument
 from labone.mock import AutomaticSessionFunctionality, spawn_hpk_mock
-
 from tests.mock_server_for_testing import get_mocked_node
 
 


### PR DESCRIPTION
This PR fixes `tests` import sorting by telling `ruff` they are part of the same source.