### PR TITLE
Upgrade zhinst-comms to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
   "typing_extensions>=4.8.0",
   "numpy>=1.20",
-  "zhinst-comms~=0.0.1",
+  "zhinst-comms~=1.1.0",
 ]
 
 [project.urls]
@@ -88,7 +88,7 @@ dependencies = [
   "mypy>=1.0.0",
   "ruff>=0.4.0",
   "numpy>=1.20",
-  "zhinst-comms~=0.0.1",
+  "zhinst-comms~=1.1.0",
 ]
 
 [tool.hatch.envs.lint.scripts]

--- a/src/labone/nodetree/helper.py
+++ b/src/labone/nodetree/helper.py
@@ -158,7 +158,7 @@ def split_path(path: LabOneNodePath) -> list[NormalizedPathSegment]:
         return []
     path_segments = path.split(PATH_SEPERATOR)
     first_item_index = 0
-    if path_segments[0] == "":  #
+    if path_segments[0] == "":
         # this happens if the path started with '/'
         # ignore leading '/'
         first_item_index = 1


### PR DESCRIPTION
Upgrade to the first "official" version of zhinst-comms. The only practical change from version 0.0.1 is that 1.1.0 supports string representation for all types. This is not a breaking change, and normally a switch of the major version would not be required, but I wanted to move away from the 0.x versions.