### PR TITLE
Adapt server to support close and run forever

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,8 @@ ignore = [
   "PLR0911",
   # Missing return type annotation for special method
   "ANN204",
+  # Too many arguments in function definition
+  "PLR0913",
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/src/labone/instrument.py
+++ b/src/labone/instrument.py
@@ -109,7 +109,7 @@ class Instrument(PartialNode):
         )
 
     @staticmethod
-    async def create(  # noqa: PLR0913
+    async def create(
         serial: str,
         *,
         host: str,

--- a/src/labone/nodetree/helper.py
+++ b/src/labone/nodetree/helper.py
@@ -158,7 +158,7 @@ def split_path(path: LabOneNodePath) -> list[NormalizedPathSegment]:
         return []
     path_segments = path.split(PATH_SEPERATOR)
     first_item_index = 0
-    if path_segments[0] == "":  #
+    if path_segments[0] == "":
         # this happens if the path started with '/'
         # ignore leading '/'
         first_item_index = 1

--- a/src/labone/nodetree/node.py
+++ b/src/labone/nodetree/node.py
@@ -534,7 +534,7 @@ class ResultNode(MetaNode):
             The time the results where created.
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         tree_manager: NodeTreeManager,
         path_segments: tuple[NormalizedPathSegment, ...],

--- a/tests/core/test_shf_vector_data.py
+++ b/tests/core/test_shf_vector_data.py
@@ -172,7 +172,7 @@ def test_shf_scope_vector(
     ],
 )
 @pytest.mark.parametrize(("x", "y"), [(0, 0), (1, 1), (32, 743)])
-def test_shf_demodulator_vector(  # noqa: PLR0913
+def test_shf_demodulator_vector(
     vector_length,
     scaling,
     timestamp_delta,

--- a/tests/mock/ab_hpk_automatic_functionality_test.py
+++ b/tests/mock/ab_hpk_automatic_functionality_test.py
@@ -73,7 +73,7 @@ def same_prints_and_exceptions_for_real_and_mock(test_function):
             exception_mock = e
         assert (exception is None) == (exception_mock is None)
         if exception is not None:
-            assert type(exception) == type(exception_mock)
+            assert type(exception) is type(exception_mock)
         assert string_output.getvalue() == string_output_mock.getvalue()
 
     return new_test_function


### PR DESCRIPTION
This commit adapts the capnp server class to support the close method and run forever method. The close method is used to stop a running server safely. Since Python does not gurantee that the destructor is called it is recommended to manage the livetime by one self. The run forever method is a simple helper function that is often usefull if a server is running in the main thread.